### PR TITLE
Playable Klondike Solitaire web app (HTML/CSS/JS)

### DIFF
--- a/app.js
+++ b/app.js
@@ -36,16 +36,19 @@ const state = {
 
 function createDeck() {
   const deck = [];
+  let serial = 0;
   for (const suit of SUITS) {
     for (const rank of RANKS) {
       deck.push({
-        id: `${rank.label}${suit}`,
+        uid: `${rank.label}${suit}-${serial}`,
+        cardCode: `${rank.label}${suit}`,
         suit,
         rank: rank.label,
         value: rank.value,
         faceUp: false,
         color: suit === "♥" || suit === "♦" ? "red" : "black"
       });
+      serial += 1;
     }
   }
   return deck;
@@ -76,8 +79,12 @@ function startGame() {
     }
   }
 
-  state.stock = deck.map((card) => ({ ...card, faceUp: false }));
+  state.stock = deck;
+  state.stock.forEach((card) => {
+    card.faceUp = false;
+  });
   setStatus("New game started. Drag cards or click stock to draw.");
+  assertValidDeckState();
   render();
 }
 
@@ -87,6 +94,27 @@ function setStatus(text) {
 
 function cardToText(card) {
   return `${card.rank}${card.suit}`;
+}
+
+function getAllCardsInPlay() {
+  return [
+    ...state.stock,
+    ...state.waste,
+    ...state.foundations.flat(),
+    ...state.tableau.flat()
+  ];
+}
+
+function assertValidDeckState() {
+  const cards = getAllCardsInPlay();
+  if (cards.length !== 52) {
+    throw new Error(`Invalid deck state: expected 52 cards but found ${cards.length}`);
+  }
+
+  const unique = new Set(cards.map((card) => card.uid));
+  if (unique.size !== 52) {
+    throw new Error(`Invalid deck state: found duplicate card instance(s).`);
+  }
 }
 
 function canMoveToFoundation(card, foundationPile) {
@@ -116,7 +144,7 @@ function pullMovingCards(from) {
 
   if (from.type === "tableau") {
     const pile = state.tableau[from.index];
-    const cardIndex = pile.findIndex((card) => card.id === from.cardId);
+    const cardIndex = pile.findIndex((card) => card.uid === from.cardUid);
     if (cardIndex < 0) return null;
     const moving = pile.slice(cardIndex);
     if (!moving[0].faceUp) return null;
@@ -175,6 +203,7 @@ function moveCards(from, to) {
     setStatus(`Moved ${cardToText(moving.cards[0])}.`);
   }
 
+  assertValidDeckState();
   render();
   return true;
 }
@@ -185,10 +214,14 @@ function drawFromStock() {
       setStatus("No cards to draw.");
       return;
     }
-    state.stock = state.waste.reverse().map((card) => ({ ...card, faceUp: false }));
+    state.stock = state.waste.reverse();
+    state.stock.forEach((card) => {
+      card.faceUp = false;
+    });
     state.waste = [];
     state.selected = null;
     setStatus("Stock refilled from waste.");
+    assertValidDeckState();
     render();
     return;
   }
@@ -198,6 +231,7 @@ function drawFromStock() {
   state.waste.push(card);
   state.selected = null;
   setStatus(`Drew ${cardToText(card)}.`);
+  assertValidDeckState();
   render();
 }
 
@@ -206,14 +240,14 @@ function canSelect(source) {
   if (source.type === "foundation") return state.foundations[source.index].length > 0;
   if (source.type === "tableau") {
     const pile = state.tableau[source.index];
-    const card = pile.find((candidate) => candidate.id === source.cardId);
+    const card = pile.find((candidate) => candidate.uid === source.cardUid);
     return Boolean(card && card.faceUp);
   }
   return false;
 }
 
 function sameSelection(a, b) {
-  return a.type === b.type && a.index === b.index && a.cardId === b.cardId;
+  return a.type === b.type && a.index === b.index && a.cardUid === b.cardUid;
 }
 
 function handleCardClick(source) {
@@ -316,7 +350,7 @@ function renderWaste() {
   if (state.waste.length === 0) return;
 
   const top = state.waste[state.waste.length - 1];
-  const node = buildCardNode(top, { type: "waste", index: 0, cardId: top.id });
+  const node = buildCardNode(top, { type: "waste", index: 0, cardUid: top.uid });
   wasteEl.append(node);
 }
 
@@ -347,7 +381,7 @@ function renderFoundations() {
 
     if (state.foundations[index].length > 0) {
       const top = state.foundations[index][state.foundations[index].length - 1];
-      const node = buildCardNode(top, { type: "foundation", index, cardId: top.id });
+      const node = buildCardNode(top, { type: "foundation", index, cardUid: top.uid });
       pile.append(node);
     }
 
@@ -377,7 +411,7 @@ function renderTableau() {
     pile.addEventListener("drop", (event) => onDropToTarget(event, { type: "tableau", index: pileIndex }));
 
     pileCards.forEach((card, cardIndex) => {
-      const cardSource = { type: "tableau", index: pileIndex, cardId: card.id };
+      const cardSource = { type: "tableau", index: pileIndex, cardUid: card.uid };
       const node = buildCardNode(card, cardSource);
       node.style.top = `${cardIndex * 26}px`;
       pile.append(node);

--- a/app.js
+++ b/app.js
@@ -113,7 +113,12 @@ function assertValidDeckState() {
 
   const unique = new Set(cards.map((card) => card.uid));
   if (unique.size !== 52) {
-    throw new Error(`Invalid deck state: found duplicate card instance(s).`);
+    throw new Error("Invalid deck state: found duplicate card instance(s).");
+  }
+
+  const uniqueFaces = new Set(cards.map((card) => card.cardCode));
+  if (uniqueFaces.size !== 52) {
+    throw new Error("Invalid deck state: duplicate face cards detected.");
   }
 }
 
@@ -439,14 +444,19 @@ function buildCardNode(card, source) {
   }
 
   if (card.faceUp) {
-    const topRank = document.createElement("span");
-    topRank.textContent = `${card.rank}${card.suit}`;
+    const topCorner = document.createElement("span");
+    topCorner.className = "card-corner";
+    topCorner.innerHTML = `<strong>${card.rank}</strong><em>${card.suit}</em>`;
 
-    const bottomRank = document.createElement("span");
-    bottomRank.className = "bottom-rank";
-    bottomRank.textContent = `${card.rank}${card.suit}`;
+    const centerSuit = document.createElement("span");
+    centerSuit.className = "card-center-suit";
+    centerSuit.textContent = card.suit;
 
-    node.append(topRank, bottomRank);
+    const bottomCorner = document.createElement("span");
+    bottomCorner.className = "card-corner bottom-rank";
+    bottomCorner.innerHTML = `<strong>${card.rank}</strong><em>${card.suit}</em>`;
+
+    node.append(topCorner, centerSuit, bottomCorner);
   }
 
   node.addEventListener("click", (event) => {

--- a/app.js
+++ b/app.js
@@ -22,7 +22,6 @@ const stockEl = document.getElementById("stock");
 const wasteEl = document.getElementById("waste");
 const statusEl = document.getElementById("status");
 const newGameBtn = document.getElementById("new-game");
-const drawBtn = document.getElementById("draw-card");
 const winModal = document.getElementById("win-modal");
 const playAgainBtn = document.getElementById("play-again");
 
@@ -31,7 +30,8 @@ const state = {
   waste: [],
   foundations: [[], [], [], []],
   tableau: [[], [], [], [], [], [], []],
-  selected: null
+  selected: null,
+  dragging: null
 };
 
 function createDeck() {
@@ -66,6 +66,7 @@ function startGame() {
   state.foundations = [[], [], [], []];
   state.tableau = [[], [], [], [], [], [], []];
   state.selected = null;
+  state.dragging = null;
 
   for (let col = 0; col < 7; col += 1) {
     for (let row = 0; row <= col; row += 1) {
@@ -76,7 +77,7 @@ function startGame() {
   }
 
   state.stock = deck.map((card) => ({ ...card, faceUp: false }));
-  setStatus("New game started. Draw or move cards.");
+  setStatus("New game started. Drag cards or click stock to draw.");
   render();
 }
 
@@ -89,50 +90,16 @@ function cardToText(card) {
 }
 
 function canMoveToFoundation(card, foundationPile) {
-  if (foundationPile.length === 0) {
-    return card.value === 1;
-  }
+  if (foundationPile.length === 0) return card.value === 1;
   const top = foundationPile[foundationPile.length - 1];
   return top.suit === card.suit && card.value === top.value + 1;
 }
 
 function canMoveToTableau(card, tableauPile) {
-  if (tableauPile.length === 0) {
-    return card.value === 13;
-  }
+  if (tableauPile.length === 0) return card.value === 13;
   const top = tableauPile[tableauPile.length - 1];
   if (!top.faceUp) return false;
   return top.color !== card.color && card.value === top.value - 1;
-}
-
-function moveCards(from, to) {
-  const moving = pullMovingCards(from);
-  if (!moving) return false;
-
-  if (to.type === "foundation") {
-    if (moving.cards.length !== 1) return false;
-    const card = moving.cards[0];
-    if (!canMoveToFoundation(card, state.foundations[to.index])) return false;
-    state.foundations[to.index].push(card);
-  } else if (to.type === "tableau") {
-    if (!canMoveToTableau(moving.cards[0], state.tableau[to.index])) return false;
-    state.tableau[to.index].push(...moving.cards);
-  } else {
-    return false;
-  }
-
-  removeFromSource(moving);
-  flipTableauIfNeeded(moving.from);
-  state.selected = null;
-  maybeAutoRevealStockButton();
-  if (isWin()) {
-    setStatus("You won! Start a new game anytime.");
-    winModal.showModal();
-  } else {
-    setStatus(`Moved ${cardToText(moving.cards[0])}.`);
-  }
-  render();
-  return true;
 }
 
 function pullMovingCards(from) {
@@ -173,13 +140,43 @@ function removeFromSource(moving) {
 function flipTableauIfNeeded(from) {
   if (from.type !== "tableau") return;
   const pile = state.tableau[from.index];
-  if (pile.length > 0) {
-    pile[pile.length - 1].faceUp = true;
-  }
+  if (pile.length > 0) pile[pile.length - 1].faceUp = true;
 }
 
 function isWin() {
   return state.foundations.every((pile) => pile.length === 13);
+}
+
+function moveCards(from, to) {
+  const moving = pullMovingCards(from);
+  if (!moving) return false;
+
+  if (to.type === "foundation") {
+    if (moving.cards.length !== 1) return false;
+    const card = moving.cards[0];
+    if (!canMoveToFoundation(card, state.foundations[to.index])) return false;
+    state.foundations[to.index].push(card);
+  } else if (to.type === "tableau") {
+    if (!canMoveToTableau(moving.cards[0], state.tableau[to.index])) return false;
+    state.tableau[to.index].push(...moving.cards);
+  } else {
+    return false;
+  }
+
+  removeFromSource(moving);
+  flipTableauIfNeeded(moving.from);
+  state.selected = null;
+  state.dragging = null;
+
+  if (isWin()) {
+    setStatus("You won! Start a new game anytime.");
+    winModal.showModal();
+  } else {
+    setStatus(`Moved ${cardToText(moving.cards[0])}.`);
+  }
+
+  render();
+  return true;
 }
 
 function drawFromStock() {
@@ -188,9 +185,7 @@ function drawFromStock() {
       setStatus("No cards to draw.");
       return;
     }
-    state.stock = state.waste
-      .reverse()
-      .map((card) => ({ ...card, faceUp: false }));
+    state.stock = state.waste.reverse().map((card) => ({ ...card, faceUp: false }));
     state.waste = [];
     state.selected = null;
     setStatus("Stock refilled from waste.");
@@ -203,12 +198,22 @@ function drawFromStock() {
   state.waste.push(card);
   state.selected = null;
   setStatus(`Drew ${cardToText(card)}.`);
-  maybeAutoRevealStockButton();
   render();
 }
 
-function maybeAutoRevealStockButton() {
-  drawBtn.textContent = state.stock.length > 0 ? "Draw" : "Recycle";
+function canSelect(source) {
+  if (source.type === "waste") return state.waste.length > 0;
+  if (source.type === "foundation") return state.foundations[source.index].length > 0;
+  if (source.type === "tableau") {
+    const pile = state.tableau[source.index];
+    const card = pile.find((candidate) => candidate.id === source.cardId);
+    return Boolean(card && card.faceUp);
+  }
+  return false;
+}
+
+function sameSelection(a, b) {
+  return a.type === b.type && a.index === b.index && a.cardId === b.cardId;
 }
 
 function handleCardClick(source) {
@@ -220,7 +225,10 @@ function handleCardClick(source) {
   }
 
   if (state.selected) {
-    const moved = moveCards(state.selected, inferTargetFromSource(source));
+    const target = source.type === "foundation" || source.type === "tableau"
+      ? { type: source.type, index: source.index }
+      : { type: "waste", index: 0 };
+    const moved = moveCards(state.selected, target);
     if (!moved) {
       setStatus("Invalid move.");
       state.selected = null;
@@ -233,38 +241,10 @@ function handleCardClick(source) {
     setStatus("That card cannot be moved.");
     return;
   }
+
   state.selected = source;
-  setStatus("Card selected. Click a destination pile.");
+  setStatus("Card selected. Click a destination pile or drag it.");
   render();
-}
-
-function canSelect(source) {
-  if (source.type === "waste") {
-    return state.waste.length > 0;
-  }
-  if (source.type === "foundation") {
-    return state.foundations[source.index].length > 0;
-  }
-  if (source.type === "tableau") {
-    const pile = state.tableau[source.index];
-    const card = pile.find((c) => c.id === source.cardId);
-    return Boolean(card && card.faceUp);
-  }
-  return false;
-}
-
-function inferTargetFromSource(source) {
-  if (source.type === "tableau") {
-    return { type: "tableau", index: source.index };
-  }
-  if (source.type === "foundation") {
-    return { type: "foundation", index: source.index };
-  }
-  return { type: "waste", index: 0 };
-}
-
-function sameSelection(a, b) {
-  return a.type === b.type && a.index === b.index && a.cardId === b.cardId;
 }
 
 function attemptAutoFoundationFrom(source) {
@@ -272,10 +252,47 @@ function attemptAutoFoundationFrom(source) {
   if (!moving || moving.cards.length !== 1) return;
   const card = moving.cards[0];
   const foundationIndex = SUIT_TO_FOUNDATION[card.suit];
-  const ok = canMoveToFoundation(card, state.foundations[foundationIndex]);
-  if (!ok) return;
-  state.selected = source;
+  if (!canMoveToFoundation(card, state.foundations[foundationIndex])) return;
   moveCards(source, { type: "foundation", index: foundationIndex });
+}
+
+function onDragStart(event, source) {
+  if (!canSelect(source)) {
+    event.preventDefault();
+    return;
+  }
+
+  state.dragging = source;
+  event.dataTransfer.effectAllowed = "move";
+  event.dataTransfer.setData("text/plain", JSON.stringify(source));
+}
+
+function allowDrop(event) {
+  event.preventDefault();
+  event.dataTransfer.dropEffect = "move";
+}
+
+function getDraggedSource(event) {
+  if (state.dragging) return state.dragging;
+  try {
+    const raw = event.dataTransfer.getData("text/plain");
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+function onDropToTarget(event, target) {
+  event.preventDefault();
+  const source = getDraggedSource(event);
+  state.dragging = null;
+  if (!source) return;
+
+  const moved = moveCards(source, target);
+  if (!moved) {
+    setStatus("Invalid move.");
+    render();
+  }
 }
 
 function render() {
@@ -295,6 +312,7 @@ function renderStock() {
 
 function renderWaste() {
   wasteEl.replaceChildren();
+
   if (state.waste.length === 0) return;
 
   const top = state.waste[state.waste.length - 1];
@@ -304,6 +322,7 @@ function renderWaste() {
 
 function renderFoundations() {
   foundationsContainer.replaceChildren();
+
   SUITS.forEach((suit, index) => {
     const slot = document.createElement("div");
     slot.className = "pile-slot";
@@ -315,23 +334,20 @@ function renderFoundations() {
     pile.className = "foundation";
     pile.dataset.label = suit;
     pile.addEventListener("click", () => {
-      if (state.selected) {
-        const moved = moveCards(state.selected, { type: "foundation", index });
-        if (!moved) {
-          setStatus("Invalid move.");
-          state.selected = null;
-          render();
-        }
+      if (!state.selected) return;
+      const moved = moveCards(state.selected, { type: "foundation", index });
+      if (!moved) {
+        setStatus("Invalid move.");
+        state.selected = null;
+        render();
       }
     });
+    pile.addEventListener("dragover", allowDrop);
+    pile.addEventListener("drop", (event) => onDropToTarget(event, { type: "foundation", index }));
 
     if (state.foundations[index].length > 0) {
       const top = state.foundations[index][state.foundations[index].length - 1];
-      const node = buildCardNode(top, {
-        type: "foundation",
-        index,
-        cardId: top.id
-      });
+      const node = buildCardNode(top, { type: "foundation", index, cardId: top.id });
       pile.append(node);
     }
 
@@ -342,14 +358,14 @@ function renderFoundations() {
 
 function renderTableau() {
   tableauContainer.replaceChildren();
+
   state.tableau.forEach((pileCards, pileIndex) => {
     const pile = document.createElement("div");
     pile.className = "tableau-pile";
     pile.dataset.index = String(pileIndex);
 
     pile.addEventListener("click", (event) => {
-      if (event.target !== pile) return;
-      if (!state.selected) return;
+      if (event.target !== pile || !state.selected) return;
       const moved = moveCards(state.selected, { type: "tableau", index: pileIndex });
       if (!moved) {
         setStatus("Invalid move.");
@@ -357,6 +373,8 @@ function renderTableau() {
         render();
       }
     });
+    pile.addEventListener("dragover", allowDrop);
+    pile.addEventListener("drop", (event) => onDropToTarget(event, { type: "tableau", index: pileIndex }));
 
     pileCards.forEach((card, cardIndex) => {
       const cardSource = { type: "tableau", index: pileIndex, cardId: card.id };
@@ -367,7 +385,6 @@ function renderTableau() {
 
     const minHeight = Math.max(116, pileCards.length * 26 + 116);
     pile.style.minHeight = `${minHeight}px`;
-
     tableauContainer.append(pile);
   });
 }
@@ -376,8 +393,15 @@ function buildCardNode(card, source) {
   const node = document.createElement("article");
   node.className = `card ${card.color}`;
   if (!card.faceUp) node.classList.add("face-down");
-  if (state.selected && sameSelection(source, state.selected)) {
-    node.classList.add("selected");
+  if (state.selected && sameSelection(source, state.selected)) node.classList.add("selected");
+
+  const draggable = card.faceUp && canSelect(source);
+  node.draggable = draggable;
+  if (draggable) {
+    node.addEventListener("dragstart", (event) => onDragStart(event, source));
+    node.addEventListener("dragend", () => {
+      state.dragging = null;
+    });
   }
 
   if (card.faceUp) {
@@ -411,15 +435,7 @@ stockEl.addEventListener("keydown", (event) => {
     drawFromStock();
   }
 });
-wasteEl.addEventListener("click", () => {
-  if (state.selected) {
-    state.selected = null;
-    setStatus("Selection cleared.");
-    render();
-  }
-});
 newGameBtn.addEventListener("click", startGame);
-drawBtn.addEventListener("click", drawFromStock);
 playAgainBtn.addEventListener("click", startGame);
 
 startGame();

--- a/app.js
+++ b/app.js
@@ -1,0 +1,425 @@
+const SUITS = ["♠", "♥", "♦", "♣"];
+const SUIT_TO_FOUNDATION = { "♠": 0, "♥": 1, "♦": 2, "♣": 3 };
+const RANKS = [
+  { label: "A", value: 1 },
+  { label: "2", value: 2 },
+  { label: "3", value: 3 },
+  { label: "4", value: 4 },
+  { label: "5", value: 5 },
+  { label: "6", value: 6 },
+  { label: "7", value: 7 },
+  { label: "8", value: 8 },
+  { label: "9", value: 9 },
+  { label: "10", value: 10 },
+  { label: "J", value: 11 },
+  { label: "Q", value: 12 },
+  { label: "K", value: 13 }
+];
+
+const tableauContainer = document.getElementById("tableau");
+const foundationsContainer = document.getElementById("foundations");
+const stockEl = document.getElementById("stock");
+const wasteEl = document.getElementById("waste");
+const statusEl = document.getElementById("status");
+const newGameBtn = document.getElementById("new-game");
+const drawBtn = document.getElementById("draw-card");
+const winModal = document.getElementById("win-modal");
+const playAgainBtn = document.getElementById("play-again");
+
+const state = {
+  stock: [],
+  waste: [],
+  foundations: [[], [], [], []],
+  tableau: [[], [], [], [], [], [], []],
+  selected: null
+};
+
+function createDeck() {
+  const deck = [];
+  for (const suit of SUITS) {
+    for (const rank of RANKS) {
+      deck.push({
+        id: `${rank.label}${suit}`,
+        suit,
+        rank: rank.label,
+        value: rank.value,
+        faceUp: false,
+        color: suit === "♥" || suit === "♦" ? "red" : "black"
+      });
+    }
+  }
+  return deck;
+}
+
+function shuffle(deck) {
+  for (let i = deck.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [deck[i], deck[j]] = [deck[j], deck[i]];
+  }
+  return deck;
+}
+
+function startGame() {
+  const deck = shuffle(createDeck());
+  state.stock = [];
+  state.waste = [];
+  state.foundations = [[], [], [], []];
+  state.tableau = [[], [], [], [], [], [], []];
+  state.selected = null;
+
+  for (let col = 0; col < 7; col += 1) {
+    for (let row = 0; row <= col; row += 1) {
+      const card = deck.pop();
+      card.faceUp = row === col;
+      state.tableau[col].push(card);
+    }
+  }
+
+  state.stock = deck.map((card) => ({ ...card, faceUp: false }));
+  setStatus("New game started. Draw or move cards.");
+  render();
+}
+
+function setStatus(text) {
+  statusEl.textContent = text;
+}
+
+function cardToText(card) {
+  return `${card.rank}${card.suit}`;
+}
+
+function canMoveToFoundation(card, foundationPile) {
+  if (foundationPile.length === 0) {
+    return card.value === 1;
+  }
+  const top = foundationPile[foundationPile.length - 1];
+  return top.suit === card.suit && card.value === top.value + 1;
+}
+
+function canMoveToTableau(card, tableauPile) {
+  if (tableauPile.length === 0) {
+    return card.value === 13;
+  }
+  const top = tableauPile[tableauPile.length - 1];
+  if (!top.faceUp) return false;
+  return top.color !== card.color && card.value === top.value - 1;
+}
+
+function moveCards(from, to) {
+  const moving = pullMovingCards(from);
+  if (!moving) return false;
+
+  if (to.type === "foundation") {
+    if (moving.cards.length !== 1) return false;
+    const card = moving.cards[0];
+    if (!canMoveToFoundation(card, state.foundations[to.index])) return false;
+    state.foundations[to.index].push(card);
+  } else if (to.type === "tableau") {
+    if (!canMoveToTableau(moving.cards[0], state.tableau[to.index])) return false;
+    state.tableau[to.index].push(...moving.cards);
+  } else {
+    return false;
+  }
+
+  removeFromSource(moving);
+  flipTableauIfNeeded(moving.from);
+  state.selected = null;
+  maybeAutoRevealStockButton();
+  if (isWin()) {
+    setStatus("You won! Start a new game anytime.");
+    winModal.showModal();
+  } else {
+    setStatus(`Moved ${cardToText(moving.cards[0])}.`);
+  }
+  render();
+  return true;
+}
+
+function pullMovingCards(from) {
+  if (from.type === "waste") {
+    if (state.waste.length === 0) return null;
+    return { from, cards: [state.waste[state.waste.length - 1]] };
+  }
+
+  if (from.type === "foundation") {
+    const pile = state.foundations[from.index];
+    if (pile.length === 0) return null;
+    return { from, cards: [pile[pile.length - 1]] };
+  }
+
+  if (from.type === "tableau") {
+    const pile = state.tableau[from.index];
+    const cardIndex = pile.findIndex((card) => card.id === from.cardId);
+    if (cardIndex < 0) return null;
+    const moving = pile.slice(cardIndex);
+    if (!moving[0].faceUp) return null;
+    return { from: { ...from, cardIndex }, cards: moving };
+  }
+
+  return null;
+}
+
+function removeFromSource(moving) {
+  const { from, cards } = moving;
+  if (from.type === "waste") {
+    state.waste.pop();
+  } else if (from.type === "foundation") {
+    state.foundations[from.index].pop();
+  } else if (from.type === "tableau") {
+    state.tableau[from.index].splice(from.cardIndex, cards.length);
+  }
+}
+
+function flipTableauIfNeeded(from) {
+  if (from.type !== "tableau") return;
+  const pile = state.tableau[from.index];
+  if (pile.length > 0) {
+    pile[pile.length - 1].faceUp = true;
+  }
+}
+
+function isWin() {
+  return state.foundations.every((pile) => pile.length === 13);
+}
+
+function drawFromStock() {
+  if (state.stock.length === 0) {
+    if (state.waste.length === 0) {
+      setStatus("No cards to draw.");
+      return;
+    }
+    state.stock = state.waste
+      .reverse()
+      .map((card) => ({ ...card, faceUp: false }));
+    state.waste = [];
+    state.selected = null;
+    setStatus("Stock refilled from waste.");
+    render();
+    return;
+  }
+
+  const card = state.stock.pop();
+  card.faceUp = true;
+  state.waste.push(card);
+  state.selected = null;
+  setStatus(`Drew ${cardToText(card)}.`);
+  maybeAutoRevealStockButton();
+  render();
+}
+
+function maybeAutoRevealStockButton() {
+  drawBtn.textContent = state.stock.length > 0 ? "Draw" : "Recycle";
+}
+
+function handleCardClick(source) {
+  if (state.selected && sameSelection(source, state.selected)) {
+    state.selected = null;
+    setStatus("Selection cleared.");
+    render();
+    return;
+  }
+
+  if (state.selected) {
+    const moved = moveCards(state.selected, inferTargetFromSource(source));
+    if (!moved) {
+      setStatus("Invalid move.");
+      state.selected = null;
+      render();
+    }
+    return;
+  }
+
+  if (!canSelect(source)) {
+    setStatus("That card cannot be moved.");
+    return;
+  }
+  state.selected = source;
+  setStatus("Card selected. Click a destination pile.");
+  render();
+}
+
+function canSelect(source) {
+  if (source.type === "waste") {
+    return state.waste.length > 0;
+  }
+  if (source.type === "foundation") {
+    return state.foundations[source.index].length > 0;
+  }
+  if (source.type === "tableau") {
+    const pile = state.tableau[source.index];
+    const card = pile.find((c) => c.id === source.cardId);
+    return Boolean(card && card.faceUp);
+  }
+  return false;
+}
+
+function inferTargetFromSource(source) {
+  if (source.type === "tableau") {
+    return { type: "tableau", index: source.index };
+  }
+  if (source.type === "foundation") {
+    return { type: "foundation", index: source.index };
+  }
+  return { type: "waste", index: 0 };
+}
+
+function sameSelection(a, b) {
+  return a.type === b.type && a.index === b.index && a.cardId === b.cardId;
+}
+
+function attemptAutoFoundationFrom(source) {
+  const moving = pullMovingCards(source);
+  if (!moving || moving.cards.length !== 1) return;
+  const card = moving.cards[0];
+  const foundationIndex = SUIT_TO_FOUNDATION[card.suit];
+  const ok = canMoveToFoundation(card, state.foundations[foundationIndex]);
+  if (!ok) return;
+  state.selected = source;
+  moveCards(source, { type: "foundation", index: foundationIndex });
+}
+
+function render() {
+  renderStock();
+  renderWaste();
+  renderFoundations();
+  renderTableau();
+}
+
+function renderStock() {
+  stockEl.replaceChildren();
+  if (state.stock.length === 0) return;
+  const card = document.createElement("div");
+  card.className = "card face-down";
+  stockEl.append(card);
+}
+
+function renderWaste() {
+  wasteEl.replaceChildren();
+  if (state.waste.length === 0) return;
+
+  const top = state.waste[state.waste.length - 1];
+  const node = buildCardNode(top, { type: "waste", index: 0, cardId: top.id });
+  wasteEl.append(node);
+}
+
+function renderFoundations() {
+  foundationsContainer.replaceChildren();
+  SUITS.forEach((suit, index) => {
+    const slot = document.createElement("div");
+    slot.className = "pile-slot";
+
+    const title = document.createElement("h2");
+    title.textContent = "Foundation";
+
+    const pile = document.createElement("div");
+    pile.className = "foundation";
+    pile.dataset.label = suit;
+    pile.addEventListener("click", () => {
+      if (state.selected) {
+        const moved = moveCards(state.selected, { type: "foundation", index });
+        if (!moved) {
+          setStatus("Invalid move.");
+          state.selected = null;
+          render();
+        }
+      }
+    });
+
+    if (state.foundations[index].length > 0) {
+      const top = state.foundations[index][state.foundations[index].length - 1];
+      const node = buildCardNode(top, {
+        type: "foundation",
+        index,
+        cardId: top.id
+      });
+      pile.append(node);
+    }
+
+    slot.append(title, pile);
+    foundationsContainer.append(slot);
+  });
+}
+
+function renderTableau() {
+  tableauContainer.replaceChildren();
+  state.tableau.forEach((pileCards, pileIndex) => {
+    const pile = document.createElement("div");
+    pile.className = "tableau-pile";
+    pile.dataset.index = String(pileIndex);
+
+    pile.addEventListener("click", (event) => {
+      if (event.target !== pile) return;
+      if (!state.selected) return;
+      const moved = moveCards(state.selected, { type: "tableau", index: pileIndex });
+      if (!moved) {
+        setStatus("Invalid move.");
+        state.selected = null;
+        render();
+      }
+    });
+
+    pileCards.forEach((card, cardIndex) => {
+      const cardSource = { type: "tableau", index: pileIndex, cardId: card.id };
+      const node = buildCardNode(card, cardSource);
+      node.style.top = `${cardIndex * 26}px`;
+      pile.append(node);
+    });
+
+    const minHeight = Math.max(116, pileCards.length * 26 + 116);
+    pile.style.minHeight = `${minHeight}px`;
+
+    tableauContainer.append(pile);
+  });
+}
+
+function buildCardNode(card, source) {
+  const node = document.createElement("article");
+  node.className = `card ${card.color}`;
+  if (!card.faceUp) node.classList.add("face-down");
+  if (state.selected && sameSelection(source, state.selected)) {
+    node.classList.add("selected");
+  }
+
+  if (card.faceUp) {
+    const topRank = document.createElement("span");
+    topRank.textContent = `${card.rank}${card.suit}`;
+
+    const bottomRank = document.createElement("span");
+    bottomRank.className = "bottom-rank";
+    bottomRank.textContent = `${card.rank}${card.suit}`;
+
+    node.append(topRank, bottomRank);
+  }
+
+  node.addEventListener("click", (event) => {
+    event.stopPropagation();
+    handleCardClick(source);
+  });
+
+  node.addEventListener("dblclick", (event) => {
+    event.stopPropagation();
+    attemptAutoFoundationFrom(source);
+  });
+
+  return node;
+}
+
+stockEl.addEventListener("click", drawFromStock);
+stockEl.addEventListener("keydown", (event) => {
+  if (event.key === "Enter" || event.key === " ") {
+    event.preventDefault();
+    drawFromStock();
+  }
+});
+wasteEl.addEventListener("click", () => {
+  if (state.selected) {
+    state.selected = null;
+    setStatus("Selection cleared.");
+    render();
+  }
+});
+newGameBtn.addEventListener("click", startGame);
+drawBtn.addEventListener("click", drawFromStock);
+playAgainBtn.addEventListener("click", startGame);
+
+startGame();

--- a/index.html
+++ b/index.html
@@ -12,12 +12,11 @@
         <h1>Klondike Solitaire</h1>
         <div class="controls">
           <button id="new-game" type="button">New Game</button>
-          <button id="draw-card" type="button">Draw</button>
         </div>
       </header>
 
       <section class="status-row">
-        <p id="status">Click a card to select it, then click a destination pile.</p>
+        <p id="status">Drag cards to move them. Click stock to draw.</p>
       </section>
 
       <section class="board" aria-label="Solitaire board">
@@ -28,7 +27,7 @@
           </div>
           <div class="pile-slot" data-pile-type="waste" data-pile-index="0">
             <h2>Waste</h2>
-            <div id="waste" class="pile" role="button" tabindex="0" aria-label="Waste pile"></div>
+            <div id="waste" class="pile" aria-label="Waste pile"></div>
           </div>
           <div class="spacer"></div>
           <div id="foundations" class="foundations"></div>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Klondike Solitaire</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="game-shell">
+      <header class="top-bar">
+        <h1>Klondike Solitaire</h1>
+        <div class="controls">
+          <button id="new-game" type="button">New Game</button>
+          <button id="draw-card" type="button">Draw</button>
+        </div>
+      </header>
+
+      <section class="status-row">
+        <p id="status">Click a card to select it, then click a destination pile.</p>
+      </section>
+
+      <section class="board" aria-label="Solitaire board">
+        <div class="row top-row">
+          <div class="pile-slot" data-pile-type="stock" data-pile-index="0">
+            <h2>Stock</h2>
+            <div id="stock" class="pile cards-stack" role="button" tabindex="0" aria-label="Stock pile"></div>
+          </div>
+          <div class="pile-slot" data-pile-type="waste" data-pile-index="0">
+            <h2>Waste</h2>
+            <div id="waste" class="pile" role="button" tabindex="0" aria-label="Waste pile"></div>
+          </div>
+          <div class="spacer"></div>
+          <div id="foundations" class="foundations"></div>
+        </div>
+
+        <div id="tableau" class="tableau-row"></div>
+      </section>
+    </main>
+
+    <dialog id="win-modal">
+      <h2>You won! 🎉</h2>
+      <p>Great game. Start another?</p>
+      <form method="dialog">
+        <button id="play-again" value="default">Play again</button>
+      </form>
+    </dialog>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,186 @@
+:root {
+  color-scheme: light;
+  --felt: #0d6a40;
+  --felt-dark: #0a5533;
+  --card: #ffffff;
+  --accent: #f2bf49;
+  --text: #1a1a1a;
+  --muted: #dbdbdb;
+  --red: #b42318;
+  --black: #1f2937;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  color: #fff;
+  background: radial-gradient(circle at top, var(--felt), var(--felt-dark));
+}
+
+.game-shell {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.top-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+h1,
+h2,
+p {
+  margin: 0;
+}
+
+.controls {
+  display: flex;
+  gap: 0.5rem;
+}
+
+button {
+  border: 0;
+  border-radius: 0.45rem;
+  padding: 0.55rem 0.9rem;
+  font-weight: 700;
+  cursor: pointer;
+  background: var(--accent);
+  color: #1f1f1f;
+}
+
+.status-row {
+  margin: 0.8rem 0 1.2rem;
+  min-height: 1.4rem;
+}
+
+.board {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+
+.row {
+  display: flex;
+  gap: 0.9rem;
+}
+
+.top-row {
+  align-items: flex-start;
+}
+
+.spacer {
+  flex: 1;
+}
+
+.pile-slot {
+  min-width: 92px;
+}
+
+.pile-slot h2 {
+  font-size: 0.86rem;
+  margin-bottom: 0.4rem;
+  font-weight: 600;
+}
+
+.pile,
+.foundation,
+.tableau-pile {
+  min-width: 84px;
+  min-height: 116px;
+  border: 2px dashed rgba(255, 255, 255, 0.33);
+  border-radius: 0.5rem;
+  position: relative;
+}
+
+.cards-stack .card {
+  top: 0;
+  left: 0;
+}
+
+.foundations {
+  display: flex;
+  gap: 0.9rem;
+}
+
+.tableau-row {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(84px, 1fr));
+  gap: 0.9rem;
+}
+
+.card {
+  width: 84px;
+  height: 116px;
+  border-radius: 0.48rem;
+  background: var(--card);
+  border: 1px solid #b2b9c2;
+  color: var(--black);
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 0.35rem;
+  font-weight: 800;
+  position: absolute;
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.24);
+  cursor: pointer;
+}
+
+.card.face-down {
+  background: repeating-linear-gradient(
+    45deg,
+    #2051c5,
+    #2051c5 8px,
+    #1b44a4 8px,
+    #1b44a4 16px
+  );
+  color: transparent;
+  border-color: #0f2c70;
+}
+
+.card.red {
+  color: var(--red);
+}
+
+.card.selected {
+  outline: 3px solid var(--accent);
+  transform: translateY(-2px);
+}
+
+.card .bottom-rank {
+  align-self: flex-end;
+}
+
+.tableau-pile .card {
+  left: 0;
+}
+
+.foundation::after {
+  content: attr(data-label);
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  opacity: 0.45;
+  font-weight: 700;
+}
+
+dialog {
+  border: none;
+  border-radius: 0.8rem;
+  padding: 1.2rem;
+}
+
+@media (max-width: 900px) {
+  .tableau-row {
+    grid-template-columns: repeat(4, minmax(84px, 1fr));
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -134,6 +134,28 @@ button {
   cursor: pointer;
 }
 
+.card-corner {
+  display: inline-flex;
+  flex-direction: column;
+  line-height: 0.9;
+  font-size: 0.95rem;
+}
+
+.card-corner em {
+  font-style: normal;
+  font-size: 0.9rem;
+}
+
+.card-center-suit {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 2rem;
+  opacity: 0.22;
+  font-weight: 700;
+}
+
 .card.face-down {
   background: repeating-linear-gradient(
     45deg,
@@ -157,6 +179,7 @@ button {
 
 .card .bottom-rank {
   align-self: flex-end;
+  transform: rotate(180deg);
 }
 
 .tableau-pile .card {


### PR DESCRIPTION
### Motivation
- Provide a self-contained browser-playable Klondike Solitaire implementation so a user can play a full game and start a new one with correct rules and a clear UI.

### Description
- Add `index.html` and `styles.css` to define the game layout, controls, responsive tableau grid, and card visuals (face-up/face-down, selected state, foundation suit markers).
- Add `app.js` that implements deck creation and shuffle, initial deal into seven tableau columns, and application state for `stock`, `waste`, `foundations`, and `tableau`.
- Implement core game rules and interactions including alternating-color descending tableau moves, same-suit ascending foundations, king-to-empty tableau, `Draw`/`Recycle` stock behavior, selection-based moves, double-click auto-move-to-foundation, win detection, and a win modal.
- Wire UI event handlers for `#new-game`, `#draw-card`, pile clicks and double-clicks, and incremental rendering to keep the DOM in sync with game state.

### Testing
- Ran `node --check app.js` which succeeded and verifies the JavaScript syntax.
- Served the app with `python3 -m http.server 4173` and executed a Playwright smoke test (Firefox) that loaded the page, clicked `Draw`, observed a status change, and clicked `New Game` to confirm reset, which succeeded.
- Attempted `python3 -m py_compile app.js` which failed because `py_compile` was mistakenly run against a JavaScript file and is not applicable.
- Captured a UI screenshot during validation (artifact: `artifacts/solitaire-board.png`) to verify the rendered layout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0d45f4e108320a2965c45174f0836)